### PR TITLE
Handle optional price in Alchemy webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ Build and start the application using Docker Compose:
 ```bash
 docker compose up --build
 ```
+
+## Alchemy Webhook
+
+POST `/webhook/alchemy` accepts JSON with the event payload from Alchemy. The
+`price_usd` field is optional and is used to calculate the USD value of the
+transfer:
+
+```json
+{
+  "event": {"activity": [...]},
+  "price_usd": 3500
+}
+```

--- a/app/core/parser.py
+++ b/app/core/parser.py
@@ -5,7 +5,7 @@ from app.core.models import Event
 def _strip_hex(value: str) -> str:
     return value.lower().removeprefix("0x")
 
-def from_alchemy(payload: dict, price_usd: Decimal) -> Event:
+def from_alchemy(payload: dict, price_usd: Decimal | None) -> Event:
     tx = payload["event"]["activity"][0]
     wei = int(tx["rawValue"])
     amount_eth = Decimal(wei) / Decimal(10 ** 18)
@@ -16,7 +16,7 @@ def from_alchemy(payload: dict, price_usd: Decimal) -> Event:
         from_addr=_strip_hex(tx["fromAddress"]),
         to_addr=_strip_hex(tx["toAddress"]),
         amount_native=amount_eth,
-        amount_usd=amount_eth * price_usd,
+        amount_usd=amount_eth * price_usd if price_usd is not None else Decimal(0),
         tx_hash=_strip_hex(tx["hash"]),
         meta={"block": tx["blockNumber"]},
     )

--- a/app/handlers/webhook.py
+++ b/app/handlers/webhook.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 class AlchemyWebhookPayload(BaseModel):
     event: dict
-    price_usd: Decimal
+    price_usd: Decimal | None = None
 
 
 @router.post("/alchemy")


### PR DESCRIPTION
## Summary
- make `price_usd` optional in the Alchemy webhook payload
- allow parser to handle missing `price_usd`
- document the webhook endpoint

## Testing
- `pre-commit run --files app/handlers/webhook.py app/core/parser.py README.md` *(fails: pre-commit not installed)*