### PR TITLE
Fix GraphQL log payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Alchemy's log webhooks:
   "price_usd": 3500
 }
 ```
+
+GraphQL log webhooks may wrap the same structure inside an `event` field:
+
+```json
+{
+  "event": {
+    "data": {"block": {"logs": [...], "number": 0, "timestamp": 0}}
+  },
+  "price_usd": 3500
+}
+```


### PR DESCRIPTION
## Summary
- handle Alchemy GraphQL log payloads delivered as `event.data`
- document support for GraphQL log webhooks

## Testing
- `ruff format app/handlers/webhook.py`
- `ruff check app/handlers/webhook.py`
- `mypy app/handlers/webhook.py` *(fails: missing type stubs)*